### PR TITLE
uadk_digest: add sha384

### DIFF
--- a/src/uadk_digest.c
+++ b/src/uadk_digest.c
@@ -52,6 +52,7 @@ static int digest_nids[] = {
 	NID_sm3,
 	NID_sha1,
 	NID_sha256,
+	NID_sha384,
 	NID_sha512,
 	0,
 	};
@@ -60,6 +61,7 @@ static EVP_MD *uadk_md5;
 static EVP_MD *uadk_sm3;
 static EVP_MD *uadk_sha1;
 static EVP_MD *uadk_sha256;
+static EVP_MD *uadk_sha384;
 static EVP_MD *uadk_sha512;
 
 static int uadk_engine_digests(ENGINE *e, const EVP_MD **digest,
@@ -84,6 +86,9 @@ static int uadk_engine_digests(ENGINE *e, const EVP_MD **digest,
 		break;
 	case NID_sha256:
 		*digest = uadk_sha256;
+		break;
+	case NID_sha384:
+		*digest = uadk_sha384;
 		break;
 	case NID_sha512:
 		*digest = uadk_sha512;
@@ -215,6 +220,12 @@ static int uadk_digest_init(EVP_MD_CTX *ctx)
 		priv->req.out_buf_bytes = 32;
 		priv->req.out_bytes = 32;
 		break;
+	case NID_sha384:
+		priv->setup.mode = WD_DIGEST_NORMAL; // fixme: how to distinguish hmac
+		priv->setup.alg = WD_DIGEST_SHA384;
+		priv->req.out_buf_bytes = 48;
+		priv->req.out_bytes = 48;
+		break;
 	case NID_sha512:
 		priv->setup.mode = WD_DIGEST_NORMAL; // fixme: how to distinguish hmac
 		priv->setup.alg = WD_DIGEST_SHA512;
@@ -340,6 +351,11 @@ int uadk_bind_digest(ENGINE *e)
 			  sizeof(EVP_MD *) + sizeof(struct digest_priv_ctx),
 			  uadk_digest_init, uadk_digest_update,
 			  uadk_digest_final, uadk_digest_cleanup);
+	UADK_DIGEST_DESCR(sha384, sha384WithRSAEncryption, 48,
+			  EVP_MD_FLAG_FIPS, 128,
+			  sizeof(EVP_MD *) + sizeof(struct digest_priv_ctx),
+			  uadk_digest_init, uadk_digest_update,
+			  uadk_digest_final, uadk_digest_cleanup);
 	UADK_DIGEST_DESCR(sha512, sha512WithRSAEncryption, 64,
 			  EVP_MD_FLAG_FIPS, 128,
 			  sizeof(EVP_MD *) + sizeof(struct digest_priv_ctx),
@@ -368,6 +384,8 @@ void uadk_destroy_digest(void)
 	uadk_sha1 = 0;
 	EVP_MD_meth_free(uadk_sha256);
 	uadk_sha256 = 0;
+	EVP_MD_meth_free(uadk_sha384);
+	uadk_sha384 = 0;
 	EVP_MD_meth_free(uadk_sha512);
 	uadk_sha512 = 0;
 }


### PR DESCRIPTION
Enable the SHA384 for UADK egine.

Signed-off-by: Kai Ye <yekai13@huawei.com>