### PR TITLE
cipher: v1 remove sm4_ecb support

### DIFF
--- a/src/v1/alg/ciphers/sec_ciphers.c
+++ b/src/v1/alg/ciphers/sec_ciphers.c
@@ -85,7 +85,6 @@ static int g_known_cipher_nids[CIPHERS_COUNT] = {
 	NID_sm4_ctr,
 	NID_sm4_cbc,
 	NID_sm4_ofb128,
-	NID_sm4_ecb,
 };
 
 #define SEC_CIPHERS_RETURN_FAIL_IF(cond, mesg, ret) \


### PR DESCRIPTION
sm4_ecb is not supported on Kunpeng920, removed in v1

Signed-off-by: Zhangfei Gao <zhangfei.gao@linaro.org>