### PR TITLE
Upstream for uadk engine

### DIFF
--- a/README
+++ b/README
@@ -68,11 +68,11 @@ Testing
 1. Cipher
 ```
 openssl enc -aes-128-cbc -a -in data -out data.en -pass pass:123456  -K abc -iv abc -engine uadk -p
-openssl enc -aes-128-cbc -a -d -in data.en -out data.de -pass pass:123456  -K abc -iv abc -engine uadk -p -nopad
+openssl enc -aes-128-cbc -a -d -in data.en -out data.de -pass pass:123456  -K abc -iv abc -engine uadk -p
 openssl enc -aes-192-cbc -a -in data -out data.en -pass pass:123456  -K abc -iv abc -engine uadk -p
-openssl enc -aes-192-cbc -a -d -in data.en -out data.de -pass pass:123456  -K abc -iv abc -engine uadk -p -nopad
+openssl enc -aes-192-cbc -a -d -in data.en -out data.de -pass pass:123456  -K abc -iv abc -engine uadk -p
 openssl enc -aes-256-cbc -a -in data -out data.en -pass pass:123456  -K abc -iv abc -engine uadk -p
-openssl enc -aes-256-cbc -a -d -in data.en -out data.de -pass pass:123456  -K abc -iv abc -engine uadk -p -nopad
+openssl enc -aes-256-cbc -a -d -in data.en -out data.de -pass pass:123456  -K abc -iv abc -engine uadk -p
 openssl enc -aes-128-ecb -a -in data -out data.en -pass pass:123456  -K abc -iv abc -engine uadk -p
 openssl enc -aes-128-ecb -a -d -in data.en -out data.de -pass pass:123456  -K abc -iv abc -engine uadk -p
 openssl enc -aes-192-ecb -a -in data -out data.en -pass pass:123456  -K abc -iv abc -engine uadk -p
@@ -80,17 +80,17 @@ openssl enc -aes-192-ecb -a -d -in data.en -out data.de -pass pass:123456  -K ab
 openssl enc -aes-256-ecb -a -in data -out data.en -pass pass:123456  -K abc -iv abc -engine uadk -p
 openssl enc -aes-256-ecb -a -d -in data.en -out data.de -pass pass:123456  -K abc -iv abc -engine uadk -p
 openssl enc -aes-128-ctr -a -in data -out data.en -pass pass:123456  -K abc -iv abc -engine uadk -p
-openssl enc -aes-128-ctr -a -d -in data.en -out data.de -pass pass:123456  -K abc -iv abc -engine uadk -p -nopad
+openssl enc -aes-128-ctr -a -d -in data.en -out data.de -pass pass:123456  -K abc -iv abc -engine uadk -p
 openssl enc -aes-192-ctr -a -in data -out data.en -pass pass:123456  -K abc -iv abc -engine uadk -p
-openssl enc -aes-192-ctr -a -d -in data.en -out data.de -pass pass:123456  -K abc -iv abc -engine uadk -p -nopad
+openssl enc -aes-192-ctr -a -d -in data.en -out data.de -pass pass:123456  -K abc -iv abc -engine uadk -p
 openssl enc -aes-256-ctr -a -in data -out data.en -pass pass:123456  -K abc -iv abc -engine uadk -p
-openssl enc -aes-256-ctr -a -d -in data.en -out data.de -pass pass:123456  -K abc -iv abc -engine uadk -p -nopad
+openssl enc -aes-256-ctr -a -d -in data.en -out data.de -pass pass:123456  -K abc -iv abc -engine uadk -p
 openssl enc -sm4-cbc -a -in data -out data.en -pass pass:123456  -K abc -iv abc -engine uadk -p
-openssl enc -sm4-cbc -a -d -in data.en -out data.de -pass pass:123456  -K abc -iv abc -engine uadk -p -nopad
+openssl enc -sm4-cbc -a -d -in data.en -out data.de -pass pass:123456  -K abc -iv abc -engine uadk -p
 openssl enc -sm4-ecb -a -in data -out data.en -pass pass:123456  -K abc -iv abc -engine uadk -p
 openssl enc -sm4-ecb -a -d -in data.en -out data.de -pass pass:123456  -K abc -iv abc -engine uadk -p
 openssl enc -des-ede3-cbc -a -in data -out data.en -pass pass:123456  -K abc -iv abc -engine uadk -p
-openssl enc -des-ede3-cbc -a -d -in data.en -out data.de -pass pass:123456  -K abc -iv abc -engine uadk -p -nopad
+openssl enc -des-ede3-cbc -a -d -in data.en -out data.de -pass pass:123456  -K abc -iv abc -engine uadk -p
 openssl enc -des-ede3-ecb -a -in data -out data.en -pass pass:123456  -K abc -iv abc -engine uadk -p
 openssl enc -des-ede3-ecb -a -d -in data.en -out data.de -pass pass:123456  -K abc -iv abc -engine uadk -p
 openssl speed -engine uadk -async_jobs 1 -evp aes-128-cbc

--- a/src/uadk_cipher.c
+++ b/src/uadk_cipher.c
@@ -655,35 +655,35 @@ int uadk_bind_cipher(ENGINE *e)
 			  sizeof(struct cipher_priv_ctx), uadk_cipher_init,
 			  uadk_do_cipher, uadk_cipher_cleanup,
 			  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
-	UADK_CIPHER_DESCR(aes_128_ctr, 16, 16, 16, EVP_CIPH_CTR_MODE,
+	UADK_CIPHER_DESCR(aes_128_ctr, 1, 16, 16, EVP_CIPH_CTR_MODE,
 			  sizeof(struct cipher_priv_ctx), uadk_cipher_init,
 			  uadk_do_cipher, uadk_cipher_cleanup,
 			  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
-	UADK_CIPHER_DESCR(aes_192_ctr, 16, 24, 16, EVP_CIPH_CTR_MODE,
+	UADK_CIPHER_DESCR(aes_192_ctr, 1, 24, 16, EVP_CIPH_CTR_MODE,
 			  sizeof(struct cipher_priv_ctx), uadk_cipher_init,
 			  uadk_do_cipher, uadk_cipher_cleanup,
 			  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
-	UADK_CIPHER_DESCR(aes_256_ctr, 16, 32, 16, EVP_CIPH_CTR_MODE,
+	UADK_CIPHER_DESCR(aes_256_ctr, 1, 32, 16, EVP_CIPH_CTR_MODE,
 			  sizeof(struct cipher_priv_ctx), uadk_cipher_init,
 			  uadk_do_cipher, uadk_cipher_cleanup,
 			  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
-	UADK_CIPHER_DESCR(aes_128_ecb, 16, 16, 16, EVP_CIPH_ECB_MODE,
+	UADK_CIPHER_DESCR(aes_128_ecb, 16, 16, 0, EVP_CIPH_ECB_MODE,
 			  sizeof(struct cipher_priv_ctx), uadk_cipher_init,
 			  uadk_do_cipher, uadk_cipher_cleanup,
 			  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
-	UADK_CIPHER_DESCR(aes_192_ecb, 16, 24, 16, EVP_CIPH_ECB_MODE,
+	UADK_CIPHER_DESCR(aes_192_ecb, 16, 24, 0, EVP_CIPH_ECB_MODE,
 			  sizeof(struct cipher_priv_ctx), uadk_cipher_init,
 			  uadk_do_cipher, uadk_cipher_cleanup,
 			  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
-	UADK_CIPHER_DESCR(aes_256_ecb, 16, 32, 16, EVP_CIPH_ECB_MODE,
+	UADK_CIPHER_DESCR(aes_256_ecb, 16, 32, 0, EVP_CIPH_ECB_MODE,
 			  sizeof(struct cipher_priv_ctx), uadk_cipher_init,
 			  uadk_do_cipher, uadk_cipher_cleanup,
 			  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
-	UADK_CIPHER_DESCR(aes_128_xts, 16, 32, 16, EVP_CIPH_XTS_MODE | EVP_CIPH_CUSTOM_IV,
+	UADK_CIPHER_DESCR(aes_128_xts, 1, 32, 0, EVP_CIPH_XTS_MODE | EVP_CIPH_CUSTOM_IV,
 			  sizeof(struct cipher_priv_ctx), uadk_cipher_init,
 			  uadk_do_cipher, uadk_cipher_cleanup,
 			  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
-	UADK_CIPHER_DESCR(aes_256_xts, 16, 64, 16, EVP_CIPH_XTS_MODE | EVP_CIPH_CUSTOM_IV,
+	UADK_CIPHER_DESCR(aes_256_xts, 1, 64, 0, EVP_CIPH_XTS_MODE | EVP_CIPH_CUSTOM_IV,
 			  sizeof(struct cipher_priv_ctx), uadk_cipher_init,
 			  uadk_do_cipher, uadk_cipher_cleanup,
 			  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
@@ -695,47 +695,47 @@ int uadk_bind_cipher(ENGINE *e)
 			  sizeof(struct cipher_priv_ctx), uadk_cipher_init,
 			  uadk_do_cipher, uadk_cipher_cleanup,
 			  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
-	UADK_CIPHER_DESCR(des_ede3_cbc, 16, 16, 16, EVP_CIPH_CBC_MODE,
+	UADK_CIPHER_DESCR(des_ede3_cbc, 8, 24, 8, EVP_CIPH_CBC_MODE,
 			  sizeof(struct cipher_priv_ctx), uadk_cipher_init,
 			  uadk_do_cipher, uadk_cipher_cleanup,
 			  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
-	UADK_CIPHER_DESCR(des_ede3_ecb, 16, 16, 16, EVP_CIPH_ECB_MODE,
+	UADK_CIPHER_DESCR(des_ede3_ecb, 8, 24, 0, EVP_CIPH_ECB_MODE,
 			  sizeof(struct cipher_priv_ctx), uadk_cipher_init,
 			  uadk_do_cipher, uadk_cipher_cleanup,
 			  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
-	UADK_CIPHER_DESCR(aes_128_ofb128, 16, 16, 16, EVP_CIPH_OFB_MODE,
+	UADK_CIPHER_DESCR(aes_128_ofb128, 1, 16, 16, EVP_CIPH_OFB_MODE,
 			  sizeof(struct cipher_priv_ctx), uadk_cipher_init,
 			  uadk_do_cipher, uadk_cipher_cleanup,
 			  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
-	UADK_CIPHER_DESCR(aes_192_ofb128, 16, 24, 16, EVP_CIPH_OFB_MODE,
+	UADK_CIPHER_DESCR(aes_192_ofb128, 1, 24, 16, EVP_CIPH_OFB_MODE,
 			  sizeof(struct cipher_priv_ctx), uadk_cipher_init,
 			  uadk_do_cipher, uadk_cipher_cleanup,
 			  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
-	UADK_CIPHER_DESCR(aes_256_ofb128, 16, 32, 16, EVP_CIPH_OFB_MODE,
+	UADK_CIPHER_DESCR(aes_256_ofb128, 1, 32, 16, EVP_CIPH_OFB_MODE,
 			  sizeof(struct cipher_priv_ctx), uadk_cipher_init,
 			  uadk_do_cipher, uadk_cipher_cleanup,
 			  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
-	UADK_CIPHER_DESCR(aes_128_cfb128, 16, 16, 16, EVP_CIPH_CFB_MODE,
+	UADK_CIPHER_DESCR(aes_128_cfb128, 1, 16, 16, EVP_CIPH_CFB_MODE,
 			  sizeof(struct cipher_priv_ctx), uadk_cipher_init,
 			  uadk_do_cipher, uadk_cipher_cleanup,
 			  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
-	UADK_CIPHER_DESCR(aes_192_cfb128, 16, 24, 16, EVP_CIPH_CFB_MODE,
+	UADK_CIPHER_DESCR(aes_192_cfb128, 1, 24, 16, EVP_CIPH_CFB_MODE,
 			  sizeof(struct cipher_priv_ctx), uadk_cipher_init,
 			  uadk_do_cipher, uadk_cipher_cleanup,
 			  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
-	UADK_CIPHER_DESCR(aes_256_cfb128, 16, 32, 16, EVP_CIPH_CFB_MODE,
+	UADK_CIPHER_DESCR(aes_256_cfb128, 1, 32, 16, EVP_CIPH_CFB_MODE,
 			  sizeof(struct cipher_priv_ctx), uadk_cipher_init,
 			  uadk_do_cipher, uadk_cipher_cleanup,
 			  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
-	UADK_CIPHER_DESCR(sm4_ofb128, 16, 16, 16, EVP_CIPH_OFB_MODE,
+	UADK_CIPHER_DESCR(sm4_ofb128, 1, 16, 16, EVP_CIPH_OFB_MODE,
 			  sizeof(struct cipher_priv_ctx), uadk_cipher_init,
 			  uadk_do_cipher, uadk_cipher_cleanup,
 			  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
-	UADK_CIPHER_DESCR(sm4_cfb128, 16, 16, 16, EVP_CIPH_OFB_MODE,
+	UADK_CIPHER_DESCR(sm4_cfb128, 1, 16, 16, EVP_CIPH_OFB_MODE,
 			  sizeof(struct cipher_priv_ctx), uadk_cipher_init,
 			  uadk_do_cipher, uadk_cipher_cleanup,
 			  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);
-	UADK_CIPHER_DESCR(sm4_ctr, 16, 16, 16, EVP_CIPH_CTR_MODE,
+	UADK_CIPHER_DESCR(sm4_ctr, 1, 16, 16, EVP_CIPH_CTR_MODE,
 			  sizeof(struct cipher_priv_ctx), uadk_cipher_init,
 			  uadk_do_cipher, uadk_cipher_cleanup,
 			  EVP_CIPHER_set_asn1_iv, EVP_CIPHER_get_asn1_iv);

--- a/src/uadk_cipher.c
+++ b/src/uadk_cipher.c
@@ -539,13 +539,21 @@ static void async_cb(struct wd_cipher_req *req, void *data)
 
 static void uadk_cipher_update_priv_ctx(struct cipher_priv_ctx *priv)
 {
-	if (priv->setup.mode == WD_CIPHER_CBC) {
-		int iv_bytes = priv->req.iv_bytes;
+	__u16 iv_bytes;
+
+	switch (priv->setup.mode) {
+	case WD_CIPHER_CBC:
+	case WD_CIPHER_OFB:
+	case WD_CIPHER_CFB:
+		iv_bytes = priv->req.iv_bytes;
 
 		if (priv->req.op_type == WD_CIPHER_ENCRYPTION) {
 			priv->req.dst += priv->req.in_bytes;
 			memcpy(priv->iv, priv->req.dst - iv_bytes, iv_bytes);
 		}
+		return;
+	default:
+		return;
 	}
 }
 

--- a/src/uadk_digest.c
+++ b/src/uadk_digest.c
@@ -41,6 +41,7 @@ struct digest_engine {
 	struct wd_ctx_config ctx_cfg;
 	struct wd_sched sched;
 	int pid;
+	pthread_spinlock_t lock;
 };
 
 static struct digest_engine engine;
@@ -77,7 +78,7 @@ static int digest_nids[] = {
 	NID_sha384,
 	NID_sha512,
 	0,
-	};
+};
 
 static EVP_MD *uadk_md5;
 static EVP_MD *uadk_sm3;
@@ -228,53 +229,84 @@ int uadk_digest_poll(void *ctx)
 	return ret;
 }
 
-static int uadk_init_digest(void)
+static int uadk_wd_digest_init(struct uacce_dev *dev)
 {
-	struct uacce_dev *dev;
-	int ret;
-	int i;
+	int ret, i;
 
-	if (engine.pid != getpid()) {
-		dev = wd_get_accel_dev("digest");
-		if (dev) {
-			memset(&engine.ctx_cfg, 0, sizeof(struct wd_ctx_config));
-			engine.ctx_cfg.ctx_num = CTX_NUM;
-			engine.ctx_cfg.ctxs = calloc(CTX_NUM, sizeof(struct wd_ctx));
-			if (!engine.ctx_cfg.ctxs)
-				return 0;
+	memset(&engine.ctx_cfg, 0, sizeof(struct wd_ctx_config));
+	engine.ctx_cfg.ctx_num = CTX_NUM;
+	engine.ctx_cfg.ctxs = calloc(CTX_NUM, sizeof(struct wd_ctx));
+	if (!engine.ctx_cfg.ctxs)
+		return -ENOMEM;
 
-			for (i = 0; i < CTX_NUM; i++) {
-				engine.ctx_cfg.ctxs[i].ctx = wd_request_ctx(dev);
-				if (!engine.ctx_cfg.ctxs[i].ctx)
-					goto err;
-
-				engine.ctx_cfg.ctxs[i].op_type = CTX_TYPE_ENCRYPT;
-				engine.ctx_cfg.ctxs[i].ctx_mode =
-					(i == 0) ? CTX_MODE_SYNC : CTX_MODE_ASYNC;
-			}
-
-			engine.sched.name = "sched_single";
-			engine.sched.pick_next_ctx = sched_single_pick_next_ctx;
-			engine.sched.poll_policy = sched_single_poll_policy;
-
-			ret = wd_digest_init(&engine.ctx_cfg, &engine.sched);
-			if (ret)
-				goto err;
-
-			async_register_poll_fn(ASYNC_TASK_DIGEST, uadk_digest_poll);
-			free(dev);
+	for (i = 0; i < CTX_NUM; i++) {
+		engine.ctx_cfg.ctxs[i].ctx = wd_request_ctx(dev);
+		if (!engine.ctx_cfg.ctxs[i].ctx) {
+			ret = -ENOMEM;
+			goto err_freectx;
 		}
-		engine.pid = getpid();
+
+		engine.ctx_cfg.ctxs[i].op_type = CTX_TYPE_ENCRYPT;
+		engine.ctx_cfg.ctxs[i].ctx_mode =
+			(i == 0) ? CTX_MODE_SYNC : CTX_MODE_ASYNC;
 	}
 
-	return 1;
+	engine.sched.name = "sched_single";
+	engine.sched.pick_next_ctx = sched_single_pick_next_ctx;
+	engine.sched.poll_policy = sched_single_poll_policy;
 
-err:
+	ret = wd_digest_init(&engine.ctx_cfg, &engine.sched);
+	if (ret)
+		goto err_freectx;
+
+	async_register_poll_fn(ASYNC_TASK_DIGEST, uadk_digest_poll);
+
+	return 0;
+
+err_freectx:
 	for (i = 0; i < engine.ctx_cfg.ctx_num; i++) {
 		if (engine.ctx_cfg.ctxs[i].ctx)
 			wd_release_ctx(engine.ctx_cfg.ctxs[i].ctx);
 	}
 	free(engine.ctx_cfg.ctxs);
+
+	return ret;
+}
+
+static int uadk_init_digest(void)
+{
+	struct uacce_dev *dev;
+	int ret;
+
+	if (engine.pid != getpid()) {
+		pthread_spin_lock(&engine.lock);
+		if (engine.pid == getpid()) {
+			pthread_spin_unlock(&engine.lock);
+			return 1;
+		}
+
+		dev = wd_get_accel_dev("digest");
+		if (!dev) {
+			pthread_spin_unlock(&engine.lock);
+			fprintf(stderr, "failed to get device for digest.\n");
+			return 0;
+		}
+
+		ret = uadk_wd_digest_init(dev);
+		if (ret)
+			goto err_unlock;
+
+		engine.pid = getpid();
+		pthread_spin_unlock(&engine.lock);
+		free(dev);
+	}
+
+	return 1;
+
+err_unlock:
+	pthread_spin_unlock(&engine.lock);
+	free(dev);
+	fprintf(stderr, "failed to init digest(%d).\n", ret);
 
 	return 0;
 }
@@ -284,8 +316,13 @@ static int uadk_digest_init(EVP_MD_CTX *ctx)
 	struct digest_priv_ctx *priv =
 		(struct digest_priv_ctx *) EVP_MD_CTX_md_data(ctx);
 	int nid = EVP_MD_nid(EVP_MD_CTX_md(ctx));
+	int ret;
 
-	uadk_init_digest();
+	ret = uadk_init_digest();
+	if (!ret) {
+		fprintf(stderr, "failed to initialize uadk digest.\n");
+		return 0;
+	}
 
 	switch (nid) {
 	case NID_md5:
@@ -511,6 +548,8 @@ int uadk_bind_digest(ENGINE *e)
 			  uadk_digest_final, uadk_digest_cleanup,
 			  uadk_digest_copy);
 
+	pthread_spin_init(&engine.lock, PTHREAD_PROCESS_PRIVATE);
+
 	return ENGINE_set_digests(e, uadk_engine_digests);
 }
 
@@ -523,7 +562,10 @@ void uadk_destroy_digest(void)
 		for (i = 0; i < engine.ctx_cfg.ctx_num; i++)
 			wd_release_ctx(engine.ctx_cfg.ctxs[i].ctx);
 		free(engine.ctx_cfg.ctxs);
+		engine.pid = 0;
 	}
+
+	pthread_spin_destroy(&engine.lock);
 
 	EVP_MD_meth_free(uadk_md5);
 	uadk_md5 = 0;


### PR DESCRIPTION
The problem is the uadk will return error if the iv is zero in XTS mode. But this is a bug for XTS. So I think fix the parameters for XTS in one patch is better, and can wait to merge this pull request after uadk fix it.