### PR TITLE
uadk: add some macro parameters

### DIFF
--- a/src/uadk.h
+++ b/src/uadk.h
@@ -19,6 +19,9 @@
 #include <openssl/engine.h>
 #include <uadk/wd.h>
 
+#define UADK_E_SUCCESS	1
+#define UADK_E_FAIL	0
+
 enum {
 	KUNPENG920,
 	KUNPENG930,


### PR DESCRIPTION
1. Add some macro parameters for the return value of the engine.
2. Add a macro to get the size of array.

Signed-off-by: Kai Ye <yekai13@huawei.com>