### PR TITLE
digest: fix the sha384 testing failed

### DIFF
--- a/src/uadk_digest.c
+++ b/src/uadk_digest.c
@@ -183,6 +183,8 @@ static int uadk_engine_digests(ENGINE *e, const EVP_MD **digest,
 	case NID_sha256:
 		*digest = uadk_sha256;
 		break;
+	case NID_sha384:
+		*digest = uadk_sha384;
 	case NID_sha512:
 		*digest = uadk_sha512;
 		break;


### PR DESCRIPTION
Fix the sha384 testing failed.

Signed-off-by: Kai Ye <yekai13@huawei.com>