### PR TITLE
ecc: support ECDH algs

### DIFF
--- a/src/uadk_pkey.c
+++ b/src/uadk_pkey.c
@@ -229,7 +229,7 @@ bool uadk_is_all_zero(const unsigned char *data, size_t dlen)
 	return true;
 }
 
-int uadk_ecc_set_public_key(handle_t sess, EC_KEY *eckey)
+int uadk_ecc_set_public_key(handle_t sess, const EC_KEY *eckey)
 {
 	unsigned char *point_bin = NULL;
 	struct wd_ecc_point pubkey;
@@ -269,7 +269,7 @@ int uadk_ecc_set_public_key(handle_t sess, EC_KEY *eckey)
 	return ret;
 }
 
-int uadk_ecc_set_private_key(handle_t sess, EC_KEY *eckey)
+int uadk_ecc_set_private_key(handle_t sess, const EC_KEY *eckey)
 {
 	unsigned char bin[UADK_ECC_MAX_KEY_BYTES];
 	struct wd_ecc_key *ecc_key;

--- a/src/uadk_pkey.h
+++ b/src/uadk_pkey.h
@@ -50,8 +50,8 @@ int uadk_ecc_get_rand(char *out, size_t out_len, void *usr);
 void uadk_ecc_cb(void);
 void uadk_ecc_fill_req(struct wd_ecc_req *req,
 			      unsigned int op, void *in, void *out);
-int uadk_ecc_set_private_key(handle_t sess, EC_KEY *eckey);
-int uadk_ecc_set_public_key(handle_t sess, EC_KEY *eckey);
+int uadk_ecc_set_private_key(handle_t sess, const EC_KEY *eckey);
+int uadk_ecc_set_public_key(handle_t sess, const EC_KEY *eckey);
 int uadk_ecc_crypto(handle_t sess, struct wd_ecc_req *req,
 		    void *usr);
 bool uadk_prime_field(const EC_GROUP *group);

--- a/test/sanity_test.sh
+++ b/test/sanity_test.sh
@@ -117,3 +117,20 @@ if [[ $algs =~ "X448" ]]; then
 	openssl speed -elapsed -engine $engine_id ecdhx448
 	openssl speed -elapsed -engine $engine_id -async_jobs 1 ecdhx448
 fi
+
+#ecdh only supported in Kunpeng930 or later
+if [[ $algs =~ "id-ecPublicKey" ]]; then
+	echo "testing ECDH"
+	openssl speed -elapsed -engine $engine_id ecdhp192
+	openssl speed -elapsed -engine $engine_id -async_jobs 1 ecdhp192
+	openssl speed -elapsed -engine $engine_id ecdhp224
+	openssl speed -elapsed -engine $engine_id -async_jobs 1 ecdhp224
+	openssl speed -elapsed -engine $engine_id ecdhp256
+	openssl speed -elapsed -engine $engine_id -async_jobs 1 ecdhp256
+	openssl speed -elapsed -engine $engine_id ecdhp384
+	openssl speed -elapsed -engine $engine_id -async_jobs 1 ecdhp384
+	openssl speed -elapsed -engine $engine_id ecdhp521
+	openssl speed -elapsed -engine $engine_id -async_jobs 1 ecdhp521
+	openssl speed -elapsed -engine $engine_id ecdhbrp384r1
+	openssl speed -elapsed -engine $engine_id -async_jobs 1 ecdhbrp384r1
+fi


### PR DESCRIPTION
This patch including:
1. support ECDH keygen and derive algs
2. support switching to openssl software methods
3. add test commands of ECDH

Signed-off-by: Zhiqi Song <songzhiqi1@huawei.com>