### PR TITLE
uadk: rename library name libuadk_engine.so

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,17 +1,17 @@
 ACLOCAL_AMFLAGS = -I m4
 
-lib_LTLIBRARIES=uadk.la
+lib_LTLIBRARIES=uadk_engine.la
 
-uadk_la_SOURCES=e_uadk.c uadk_cipher.c uadk_digest.c uadk_async.c uadk_rsa.c \
+uadk_engine_la_SOURCES=e_uadk.c uadk_cipher.c uadk_digest.c uadk_async.c uadk_rsa.c \
 		uadk_sm2.c uadk_pkey.c uadk_dh.c uadk_ec.c uadk_ecx.c
-uadk_la_LIBADD=-ldl -lwd -lwd_crypto -lpthread
-uadk_la_LDFLAGS=-module
+uadk_engine_la_LIBADD=-ldl -lwd -lwd_crypto -lpthread
+uadk_engine_la_LDFLAGS=-module
 
 AUTOMAKE_OPTIONS = subdir-objects
 
 if WD_KAE
 AM_CFLAGS = -DKAE
-uadk_la_SOURCES+=v1/alg/ciphers/sec_ciphers.c \
+uadk_engine_la_SOURCES+=v1/alg/ciphers/sec_ciphers.c \
 		 v1/alg/ciphers/sec_ciphers_soft.c \
 		 v1/alg/ciphers/sec_ciphers_utils.c \
 		 v1/alg/ciphers/sec_ciphers_wd.c \

--- a/src/e_uadk.c
+++ b/src/e_uadk.c
@@ -27,7 +27,7 @@
 #endif
 
 /* Constants used when creating the ENGINE */
-const char *engine_uadk_id = "uadk";
+const char *engine_uadk_id = "uadk_engine";
 static const char *engine_uadk_name = "uadk hardware engine support";
 
 static int uadk_cipher;

--- a/test/sanity_test.sh
+++ b/test/sanity_test.sh
@@ -3,7 +3,7 @@
 chmod 666 /dev/hisi_*
 
 if [ ! -n "$1" ]; then
-	engine_id=uadk
+	engine_id=uadk_engine
 else
 	engine_id=$1
 fi


### PR DESCRIPTION
1. If no openssl.cnf like ci
openssl engine -c uadk /usr/local/lib/engines-1.1/libuadk_engine.so

2. If prividing /usr/local/ssl/openssl.cnf
The loading library can be specified in openssl.cnf by [engine_section]
Or dynamic_path in [uadk_section]

[engine_section]
// by default loading /usr/local/lib/engines-1.1/libuadk_engine.so
libuadk_engine = uadk_section

// by default loading /usr/local/lib/engines-1.1/uadk.so
uadk = uadk_section　　　　　

Or specified by:
[uadk_section]
dynamic_path = /usr/local/lib/engines-1.1/libuadk_engine.so

For example
/usr/local/ssl/openssl.cnf:

openssl_conf = openssl_def
[openssl_def]
engines = engine_section
[engine_section]
libuadk_engine = uadk_section
[uadk_section]
dynamic_path = /usr/local/lib/engines-1.1/libuadk_engine.so
default_algorithms = ALL

Signed-off-by: Zhangfei Gao <zhangfei.gao@linaro.org>