### PR TITLE
uadk_provider: fix OpenSSL 3.5 compatibility issues

### DIFF
--- a/src/uadk_prov_aead.c
+++ b/src/uadk_prov_aead.c
@@ -115,6 +115,7 @@ static struct aead_info aead_info_table[] = {
 	{ NID_aes_256_gcm, WD_CIPHER_AES, WD_CIPHER_GCM }
 };
 
+# if OPENSSL_VERSION_NUMBER <= 0x30200000L
 static EVP_CIPHER_CTX *EVP_CIPHER_CTX_dup(const EVP_CIPHER_CTX *in)
 {
 	EVP_CIPHER_CTX *out = EVP_CIPHER_CTX_new();
@@ -126,6 +127,7 @@ static EVP_CIPHER_CTX *EVP_CIPHER_CTX_dup(const EVP_CIPHER_CTX *in)
 
 	return out;
 }
+# endif
 
 static int uadk_aead_poll(void *ctx)
 {

--- a/src/uadk_prov_digest.c
+++ b/src/uadk_prov_digest.c
@@ -123,6 +123,7 @@ static struct digest_info digest_info_table[] = {
 	32, SHA_SMALL_PACKET_OFFLOAD_THRESHOLD_DEFAULT},
 };
 
+# if OPENSSL_VERSION_NUMBER <= 0x30200000L
 static EVP_MD_CTX *EVP_MD_CTX_dup(const EVP_MD_CTX *in)
 {
 	EVP_MD_CTX *out = EVP_MD_CTX_new();
@@ -133,6 +134,7 @@ static EVP_MD_CTX *EVP_MD_CTX_dup(const EVP_MD_CTX *in)
 	}
 	return out;
 }
+# endif
 
 static int uadk_create_digest_soft_ctx(struct digest_priv_ctx *priv)
 {

--- a/src/uadk_prov_ec_kmgmt.c
+++ b/src/uadk_prov_ec_kmgmt.c
@@ -412,6 +412,7 @@ static void uadk_keymgmt_ec_gen_cleanup(void *genctx)
 	if (!gctx)
 		return;
 
+	OPENSSL_clear_free(gctx->dhkem_ikm, gctx->dhkem_ikmlen);
 	EC_GROUP_free(gctx->gen_group);
 	BN_free(gctx->p);
 	BN_free(gctx->a);
@@ -620,6 +621,13 @@ static int uadk_keymgmt_ec_gen_set_params(void *genctx, const OSSL_PARAM params[
 	if (!ret)
 		return ret;
 
+# if OPENSSL_VERSION_NUMBER >= 0x30200000L
+	ret = ec_set_octet_param(OSSL_PKEY_PARAM_DHKEM_IKM, &gctx->dhkem_ikm,
+				 &gctx->dhkem_ikmlen, params);
+	if (!ret)
+		return ret;
+# endif
+
 	return ec_set_octet_param(OSSL_PKEY_PARAM_EC_GENERATOR,
 				  &gctx->gen, &gctx->gen_len, params);
 }
@@ -640,8 +648,11 @@ static const OSSL_PARAM *uadk_keymgmt_ec_gen_settable_params(ossl_unused void *g
 		OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_EC_GENERATOR, NULL, 0),
 		OSSL_PARAM_BN(OSSL_PKEY_PARAM_EC_ORDER, NULL, 0),
 		OSSL_PARAM_BN(OSSL_PKEY_PARAM_EC_COFACTOR, NULL, 0),
-		OSSL_PARAM_BN(OSSL_PKEY_PARAM_PRIV_KEY, NULL, 0),
 		OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_EC_SEED, NULL, 0),
+# if OPENSSL_VERSION_NUMBER >= 0x30200000L
+		OSSL_PARAM_octet_string(OSSL_PKEY_PARAM_DHKEM_IKM, NULL, 0),
+# endif
+		OSSL_PARAM_BN(OSSL_PKEY_PARAM_PRIV_KEY, NULL, 0),
 		OSSL_PARAM_END
 	};
 

--- a/src/uadk_prov_ecdsa.c
+++ b/src/uadk_prov_ecdsa.c
@@ -53,7 +53,9 @@ struct ecdsa_ctx {
 
 	/* The Algorithm Identifier of the combined signature algorithm */
 	unsigned char aid_buf[MAX_ALGORITHM_ID_SIZE];
+#if OPENSSL_VERSION_NUMBER < 0x30400000L
 	unsigned char *aid;
+#endif
 	size_t aid_len;
 	size_t mdsize;
 	int operation;
@@ -174,6 +176,7 @@ err:
 
 static void ecdsa_set_aid(struct ecdsa_ctx *ctx, int md_nid)
 {
+	unsigned char *aid = NULL;
 	WPACKET pkt;
 
 	ctx->aid_len = 0;
@@ -181,9 +184,11 @@ static void ecdsa_set_aid(struct ecdsa_ctx *ctx, int md_nid)
 	    ossl_DER_w_algorithmIdentifier_ECDSA_with_MD(&pkt, -1, ctx->ec, md_nid) &&
 	    WPACKET_finish(&pkt)) {
 		WPACKET_get_total_written(&pkt, &ctx->aid_len);
-		ctx->aid = WPACKET_get_curr(&pkt);
+		aid = WPACKET_get_curr(&pkt);
 	}
 	WPACKET_cleanup(&pkt);
+	if (aid && ctx->aid_len)
+		memmove(ctx->aid_buf, aid, ctx->aid_len);
 }
 
 /*
@@ -969,13 +974,17 @@ static int uadk_signature_ecdsa_digest_verify_final(void *vctx, const unsigned c
 
 static int ecdsa_get_ctx_aid(struct ecdsa_ctx *ctx, OSSL_PARAM *params)
 {
+	unsigned char *aid = NULL;
 	OSSL_PARAM *p;
+
+	if (ctx->aid_len)
+		aid = ctx->aid_buf;
 
 	p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_ALGORITHM_ID);
 	if (!p)
 		return UADK_P_SUCCESS;
 
-	return OSSL_PARAM_set_octet_string(p, ctx->aid, ctx->aid_len);
+	return OSSL_PARAM_set_octet_string(p, aid, ctx->aid_len);
 }
 
 static int ecdsa_get_ctx_digest_size(struct ecdsa_ctx *ctx, OSSL_PARAM *params)

--- a/src/uadk_prov_ecx.c
+++ b/src/uadk_prov_ecx.c
@@ -147,6 +147,10 @@ typedef struct {
 	char *propq;
 	ECX_KEY_TYPE type;
 	int selection;
+# if OPENSSL_VERSION_NUMBER >= 0x30200000L
+	unsigned char *dhkem_ikm;
+	size_t dhkem_ikmlen;
+# endif
 	size_t keylen;
 	/* uadk sesssion */
 	handle_t sess;

--- a/src/uadk_prov_pkey.h
+++ b/src/uadk_prov_pkey.h
@@ -121,6 +121,8 @@ struct ec_gen_ctx {
 	int selection;
 	int ecdh_mode;
 	EC_GROUP *gen_group;
+	unsigned char *dhkem_ikm;
+	size_t dhkem_ikmlen;
 	BIGNUM *priv_key;
 };
 
@@ -129,12 +131,17 @@ typedef struct {
 	int id;
 
 	int name_id;
+#if OPENSSL_VERSION_NUMBER >= 0x30300000L
+	/* NID for the legacy alg if there is one */
+	int legacy_alg;
+# endif
 	char *type_name;
 	const char *description;
 	OSSL_PROVIDER *prov;
 	int refcnt;
+#if OPENSSL_VERSION_NUMBER < 0x30200000L
 	void *lock;
-
+# endif
 	/* Constructor(s), destructor, information */
 	OSSL_FUNC_keymgmt_new_fn *new_fun;
 	OSSL_FUNC_keymgmt_free_fn *free;
@@ -146,6 +153,10 @@ typedef struct {
 	/* Generation, a complex constructor */
 	OSSL_FUNC_keymgmt_gen_init_fn *gen_init;
 	OSSL_FUNC_keymgmt_gen_set_template_fn *gen_set_template;
+#if OPENSSL_VERSION_NUMBER >= 0x30400000L
+	OSSL_FUNC_keymgmt_gen_get_params_fn *gen_get_params;
+	OSSL_FUNC_keymgmt_gen_gettable_params_fn *gen_gettable_params;
+# endif
 	OSSL_FUNC_keymgmt_gen_set_params_fn *gen_set_params;
 	OSSL_FUNC_keymgmt_gen_settable_params_fn *gen_settable_params;
 	OSSL_FUNC_keymgmt_gen_fn *gen;
@@ -161,8 +172,14 @@ typedef struct {
 	/* Import and export routines */
 	OSSL_FUNC_keymgmt_import_fn *import;
 	OSSL_FUNC_keymgmt_import_types_fn *import_types;
+#if OPENSSL_VERSION_NUMBER >= 0x30200000L
+	OSSL_FUNC_keymgmt_import_types_ex_fn *import_types_ex;
+# endif
 	OSSL_FUNC_keymgmt_export_fn *export_fun;
 	OSSL_FUNC_keymgmt_export_types_fn *export_types;
+#if OPENSSL_VERSION_NUMBER >= 0x30200000L
+	OSSL_FUNC_keymgmt_export_types_ex_fn *export_types_ex;
+# endif
 	OSSL_FUNC_keymgmt_dup_fn *dup;
 } UADK_PKEY_KEYMGMT;
 
@@ -228,13 +245,24 @@ typedef struct {
 	const char *description;
 	OSSL_PROVIDER *prov;
 	int refcnt;
+#if OPENSSL_VERSION_NUMBER < 0x30200000L
 	void *lock;
-
+#endif
 	OSSL_FUNC_signature_newctx_fn *newctx;
 	OSSL_FUNC_signature_sign_init_fn *sign_init;
 	OSSL_FUNC_signature_sign_fn *sign;
+#if OPENSSL_VERSION_NUMBER >= 0x30400000L
+	OSSL_FUNC_signature_sign_message_init_fn *sign_message_init;
+	OSSL_FUNC_signature_sign_message_update_fn *sign_message_update;
+	OSSL_FUNC_signature_sign_message_final_fn *sign_message_final;
+#endif
 	OSSL_FUNC_signature_verify_init_fn *verify_init;
 	OSSL_FUNC_signature_verify_fn *verify;
+#if OPENSSL_VERSION_NUMBER >= 0x30400000L
+	OSSL_FUNC_signature_verify_message_init_fn *verify_message_init;
+	OSSL_FUNC_signature_verify_message_update_fn *verify_message_update;
+	OSSL_FUNC_signature_verify_message_final_fn *verify_message_final;
+#endif
 	OSSL_FUNC_signature_verify_recover_init_fn *verify_recover_init;
 	OSSL_FUNC_signature_verify_recover_fn *verify_recover;
 	OSSL_FUNC_signature_digest_sign_init_fn *digest_sign_init;
@@ -330,8 +358,9 @@ typedef struct {
 	const char *description;
 	OSSL_PROVIDER *prov;
 	int refcnt;
+#if OPENSSL_VERSION_NUMBER < 0x30200000L
 	void *lock;
-
+#endif
 	OSSL_FUNC_asym_cipher_newctx_fn *newctx;
 	OSSL_FUNC_asym_cipher_encrypt_init_fn *encrypt_init;
 	OSSL_FUNC_asym_cipher_encrypt_fn *encrypt;
@@ -384,7 +413,9 @@ typedef struct {
 	const char *description;
 	OSSL_PROVIDER *prov;
 	int refcnt;
+#if OPENSSL_VERSION_NUMBER < 0x30200000L
 	void *lock;
+#endif
 
 	OSSL_FUNC_keyexch_newctx_fn *newctx;
 	OSSL_FUNC_keyexch_init_fn *init;

--- a/src/uadk_prov_rsa_enc.c
+++ b/src/uadk_prov_rsa_enc.c
@@ -44,7 +44,10 @@ struct PROV_RSA_ASYM_CTX {
 	/* TLS padding */
 	unsigned int client_version;
 	unsigned int alt_version;
-
+#if OPENSSL_VERSION_NUMBER >= 0x30200000L
+	/* PKCS#1 v1.5 decryption mode */
+	unsigned int implicit_rejection;
+# endif
 	unsigned int soft : 1;
 };
 

--- a/src/uadk_prov_rsa_sign.c
+++ b/src/uadk_prov_rsa_sign.c
@@ -44,6 +44,9 @@ struct PROV_RSA_SIG_CTX {
 	 */
 	unsigned int flag_allow_md : 1;
 	unsigned int mgf1_md_set : 1;
+	unsigned int flag_allow_update : 1;
+	unsigned int flag_allow_final : 1;
+	unsigned int flag_allow_oneshot : 1;
 
 	/* main digest */
 	EVP_MD *md;
@@ -61,6 +64,10 @@ struct PROV_RSA_SIG_CTX {
 	int saltlen;
 	/* Minimum salt length or -1 if no PSS parameter restriction */
 	int min_saltlen;
+#if OPENSSL_VERSION_NUMBER >= 0x30400000L
+	unsigned char *sig;
+	size_t siglen;
+#endif
 
 	/* Temp buffer */
 	unsigned char *tbuf;

--- a/src/uadk_prov_sm2_sign.c
+++ b/src/uadk_prov_sm2_sign.c
@@ -61,8 +61,10 @@ typedef struct {
 
 	/* The Algorithm Identifier of the combined signature algorithm */
 	unsigned char aid_buf[OSSL_MAX_ALGORITHM_ID_SIZE];
+#if OPENSSL_VERSION_NUMBER < 0x30400000L
 	unsigned char *aid;
-	size_t  aid_len;
+#endif
+	size_t aid_len;
 
 	/* main digest */
 	EVP_MD *md;
@@ -755,6 +757,7 @@ static int sm2_digest_signverify_init(void *vpsm2ctx, const char *mdname,
 				      void *ec, const OSSL_PARAM params[])
 {
 	PROV_SM2_SIGN_CTX *psm2ctx = (PROV_SM2_SIGN_CTX *)vpsm2ctx;
+	unsigned char *aid = NULL;
 	int md_nid;
 	WPACKET pkt;
 
@@ -784,9 +787,11 @@ static int sm2_digest_signverify_init(void *vpsm2ctx, const char *mdname,
 	    ossl_DER_w_algorithmIdentifier_SM2_with_MD(&pkt, -1, psm2ctx->key, md_nid) &&
 	    WPACKET_finish(&pkt)) {
 		WPACKET_get_total_written(&pkt, &psm2ctx->aid_len);
-		psm2ctx->aid = WPACKET_get_curr(&pkt);
+		aid = WPACKET_get_curr(&pkt);
 	}
 	WPACKET_cleanup(&pkt);
+	if (aid && psm2ctx->aid_len)
+		memmove(psm2ctx->aid_buf, aid, psm2ctx->aid_len);
 
 	if (!EVP_DigestInit_ex2(psm2ctx->mdctx, psm2ctx->md, params)) {
 		UADK_ERR("failed to do digest init\n");
@@ -1240,6 +1245,7 @@ static const OSSL_PARAM *uadk_signature_sm2_gettable_ctx_params(ossl_unused void
 static int uadk_signature_sm2_get_ctx_params(void *vpsm2ctx, OSSL_PARAM *params)
 {
 	PROV_SM2_SIGN_CTX *psm2ctx = (PROV_SM2_SIGN_CTX *)vpsm2ctx;
+	unsigned char *aid = NULL;
 	OSSL_PARAM *p;
 
 	if (!psm2ctx) {
@@ -1247,8 +1253,10 @@ static int uadk_signature_sm2_get_ctx_params(void *vpsm2ctx, OSSL_PARAM *params)
 		return UADK_P_FAIL;
 	}
 
+	if (psm2ctx->aid_len)
+		aid = psm2ctx->aid_buf;
 	p = OSSL_PARAM_locate(params, OSSL_SIGNATURE_PARAM_ALGORITHM_ID);
-	if (p && !OSSL_PARAM_set_octet_string(p, psm2ctx->aid, psm2ctx->aid_len)) {
+	if (p != NULL && !OSSL_PARAM_set_octet_string(p, aid, psm2ctx->aid_len)) {
 		UADK_ERR("failed to locate algorithm id\n");
 		return UADK_P_FAIL;
 	}


### PR DESCRIPTION
The OpenSSL version macro is used to solve the compatibility issues between the uadk provider and OpenSSL 3.5.